### PR TITLE
Fix multi-line lambda source cleanup and enable tests (closes #6, #10)

### DIFF
--- a/src/nobe/source.py
+++ b/src/nobe/source.py
@@ -5,14 +5,18 @@ from typing import Callable
 
 
 def _cleanup(source):
-    # Handle nb.code with lambda
+    # Handle nb.code with single-line lambda
     source = re.sub(r"\s*nb\.code\(lambda: (.*?)\)", r"\1", source)
     # Remove nb.code decorator and any function definition
     source = re.sub(r"\s*@nb\.code\s*\n\s*def \w+\(\):\n", "", source)
     # remove global variable declarations
     source = re.sub(r"^\s*global\s+.*$", "", source, flags=re.MULTILINE)
     # Remove indentation using dedent
-    return dedent(source).strip()
+    source = dedent(source).strip()
+    # Handle multi-line lambda: inspect.getsource returns the lambda expression
+    # itself (e.g. "lambda: call(\n    ...\n)"), so strip the "lambda: " prefix.
+    source = re.sub(r"^lambda: ", "", source)
+    return source
 
 
 def getsource(callable: Callable):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -20,12 +20,29 @@ cleaned_simple_decorator = """
 print("hello")
 """
 
+# When inspect.getsource is called on a multi-line lambda,
+# it returns the lambda expression itself (starting with "lambda: ").
+# The _cleanup function should strip that prefix.
+source_multiline_lambda = """\
+    lambda: nb.image(
+        url="https://example.com",
+        alt="example image",
+    )
+"""
+
+cleaned_multiline_lambda = """\
+nb.image(
+    url="https://example.com",
+    alt="example image",
+)"""
+
 cleanup_test_data = [
     (source_simple_lambda, cleaned_simple_lambda),
     (source_simple_decorator, cleaned_simple_decorator),
+    (source_multiline_lambda, cleaned_multiline_lambda),
 ]
 
 
 @pytest.mark.parametrize("source, cleaned", cleanup_test_data)
 def test_source_cleanup(source: str, cleaned: str):
-    pass
+    assert _cleanup(source) == cleaned.strip()


### PR DESCRIPTION
- source.py: after dedent/strip, strip leading "lambda: " prefix so that
  multi-line lambdas (where inspect.getsource returns the lambda expression
  itself) are cleaned correctly
- test_source.py: replace pass-only body with an actual assertion, and add
  a parametrized test case for the multi-line lambda edge case

https://claude.ai/code/session_01MLzNbXdZRPnYZrQLsVwStm